### PR TITLE
Fix error.

### DIFF
--- a/GraphNorm_ws/ogbg_ws/src/dgl_model/norm.py
+++ b/GraphNorm_ws/ogbg_ws/src/dgl_model/norm.py
@@ -20,7 +20,7 @@ class Norm(nn.Module):
             return self.norm(tensor)
         elif self.norm is None:
             return tensor
-        batch_list = graph.batch_num_nodes
+        batch_list = graph.batch_num_nodes()
         batch_size = len(batch_list)
         batch_list = torch.Tensor(batch_list).long().to(tensor.device)
         batch_index = torch.arange(batch_size).to(tensor.device).repeat_interleave(batch_list)


### PR DESCRIPTION
The code runs into the error:

TypeError: object of type 'method' has no len()

Adding the parenthesis solves the error. I don't know if there have been any changes in the dgl API but batch_num_nodes is a method, not an attribute.